### PR TITLE
php 8.0 compatibility fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,6 @@ jobs:
       matrix:
         php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         include:
-          - php: '8.0'
-            allow-failure: true
           - php: '8.1'
             allow-failure: true
 
@@ -31,9 +29,6 @@ jobs:
           ini-values: apc.enable_cli=1
         env:
             fail-fast: true
-
-      - name: Display APC versions (if installed)
-        run: php -r "echo phpversion('apc');"
 
       - name: "Run Tests"
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 1.3.3
 -----
-- php 8.0 compatibility fix [#8](https://github.com/ovos/doctrine1/pull/8)
+- php 8.0 compatibility fixes [#8](https://github.com/ovos/doctrine1/pull/8)
 
 1.3.2
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.3.3
+-----
+- php 8.0 compatibility fix [#8](https://github.com/ovos/doctrine1/pull/8)
+
 1.3.2
 -----
 - fixed Doctrine_Validator_HtmlColor class name to match the filename and fix compatibility with psr-0 autoloading

--- a/lib/Doctrine/Import/Builder.php
+++ b/lib/Doctrine/Import/Builder.php
@@ -767,7 +767,7 @@ class Doctrine_Import_Builder extends Doctrine_Builder
      * @param array  $emittedActAs contains on output an array of actAs command to be appended to output
      * @return string actAs full definition
      */
-    private function innerBuildActAs($actAs, $level = 0, $parent = null, array &$emittedActAs)
+    private function innerBuildActAs($actAs, $level, $parent, array &$emittedActAs)
     {
         // rewrite special case of actAs: [Behavior] which gave [0] => Behavior
         if (is_array($actAs) && isset($actAs[0]) && !is_array($actAs[0])) {

--- a/lib/Doctrine/Query/Abstract.php
+++ b/lib/Doctrine/Query/Abstract.php
@@ -2465,7 +2465,7 @@ abstract class Doctrine_Query_Abstract
      * @param array $tableAliases
      * @return $this
      */
-    public function addDependences($sqlPart = null, array $tableAliases)
+    public function addDependences($sqlPart, array $tableAliases)
     {
         foreach($tableAliases as $tableAlias) {
             $this->addDependency($sqlPart, $tableAlias);

--- a/lib/Doctrine/Query/Having.php
+++ b/lib/Doctrine/Query/Having.php
@@ -89,7 +89,7 @@ class Doctrine_Query_Having extends Doctrine_Query_Condition
      * @param mixed $value
      * @return string
      */
-    final private function _parseAliases($value)
+    private function _parseAliases($value)
     {
         if ( ! is_numeric($value)) {
             $a = explode('.', $value);


### PR DESCRIPTION
- fixed PHP8 errors:
  - `PHP Deprecated:  Required parameter $tableAliases follows optional parameter $sqlPart in lib/Doctrine/Query/Abstract.php on line 2468`
  - `PHP Deprecated:  Required parameter $emittedActAs follows optional parameter $level in lib/Doctrine/Import/Builder.php on line 770`
  - `PHP Warning:  Private methods cannot be final as they are never overridden by other classes in lib/Doctrine/Query/Having.php on line 92`
