### PR TITLE
php 8.1 compatibility fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ root = true
 
 [*]
 charset = utf-8
+insert_final_newline = false
 
 [*.yml]
 end_of_line = lf

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         include:
-          - php: '8.1'
+          - php: '8.2'
             allow-failure: true
 
     steps:

--- a/lib/Doctrine/Access.php
+++ b/lib/Doctrine/Access.php
@@ -100,6 +100,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @param   mixed $offset
      * @return  boolean Whether or not this object contains $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->contains($offset);
@@ -112,6 +113,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @param   mixed $offset
      * @return  mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->get($offset);
@@ -125,6 +127,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @param   mixed $value
      * @return  void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if ( ! isset($offset)) {
@@ -140,6 +143,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @see   set, offsetSet, __set
      * @param mixed $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         return $this->remove($offset);

--- a/lib/Doctrine/Adapter/Mock.php
+++ b/lib/Doctrine/Adapter/Mock.php
@@ -61,6 +61,11 @@ class Doctrine_Adapter_Mock implements Doctrine_Adapter_Interface, Countable
     private $_lastInsertIdFail = false;
 
     /**
+     * @var int
+     */
+    protected $_count;
+
+    /**
      * Doctrine mock adapter constructor
      *
      * <code>
@@ -238,6 +243,7 @@ class Doctrine_Adapter_Mock implements Doctrine_Adapter_Interface, Countable
      *
      * @return integer $count
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_queries);

--- a/lib/Doctrine/Collection.php
+++ b/lib/Doctrine/Collection.php
@@ -145,9 +145,20 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     /**
      * This method is automatically called when this Doctrine_Collection is serialized
      *
-     * @return array
+     * @return string
      */
     public function serialize()
+    {
+        return serialize($this->__serialize());
+    }
+
+    /**
+     * As of PHP 8.1.0, a class which implements Serializable without also implementing __serialize() and __unserialize() will generate a deprecation warning.
+     * @see https://php.watch/versions/8.1/serializable-deprecated
+     *
+     * @return array
+     */
+    public function __serialize()
     {
         $vars = get_object_vars($this);
 
@@ -165,7 +176,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
 
         $vars['_table'] = $vars['_table']->getComponentName();
 
-        return serialize($vars);
+        return $vars;
     }
 
     /**
@@ -175,10 +186,19 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      */
     public function unserialize($serialized)
     {
+        $this->__unserialize(unserialize($serialized));
+    }
+    
+    /**
+     * As of PHP 8.1.0, a class which implements Serializable without also implementing __serialize() and __unserialize() will generate a deprecation warning.
+     * @see https://php.watch/versions/8.1/serializable-deprecated
+     *
+     * @param array $array
+     */
+    public function __unserialize(array $array)
+    {
         $manager    = Doctrine_Manager::getInstance();
         $connection    = $manager->getCurrentConnection();
-
-        $array = unserialize($serialized);
 
         foreach ($array as $name => $values) {
             $this->$name = $values;
@@ -425,6 +445,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      *
      * @return integer
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->data);
@@ -1047,6 +1068,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      *
      * @return Iterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $data = $this->data;

--- a/lib/Doctrine/Collection/OnDemand.php
+++ b/lib/Doctrine/Collection/OnDemand.php
@@ -64,6 +64,7 @@ class Doctrine_Collection_OnDemand implements Iterator
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->index = 0;
@@ -73,16 +74,19 @@ class Doctrine_Collection_OnDemand implements Iterator
         $this->_hydrateCurrent();
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->index;
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->_current;
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->_current = null;
@@ -90,6 +94,7 @@ class Doctrine_Collection_OnDemand implements Iterator
         $this->_hydrateCurrent();
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         if ( ! is_null($this->_current) && $this->_current !== false) {

--- a/lib/Doctrine/Connection.php
+++ b/lib/Doctrine/Connection.php
@@ -1154,6 +1154,7 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      *
      * @return ArrayIterator        SPL ArrayIterator object
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->tables);
@@ -1164,6 +1165,7 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      *
      * @return integer
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->_count;
@@ -1560,14 +1562,26 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
     /**
      * Serialize. Remove database connection(pdo) since it cannot be serialized
      *
-     * @return string $serialized
+     * @return string
      */
     public function serialize()
+    {
+        return serialize($this->__serialize());
+    }
+    
+    /**
+     * As of PHP 8.1.0, a class which implements Serializable without also implementing __serialize() and __unserialize() will generate a deprecation warning.
+     * @see https://php.watch/versions/8.1/serializable-deprecated
+     *
+     * @return array
+     */
+    public function __serialize()
     {
         $vars = get_object_vars($this);
         $vars['dbh'] = null;
         $vars['isConnected'] = false;
-        return serialize($vars);
+
+        return $vars;
     }
 
     /**
@@ -1578,8 +1592,17 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      */
     public function unserialize($serialized)
     {
-        $array = unserialize($serialized);
-
+        $this->__unserialize(unserialize($serialized));
+    }
+    
+    /**
+     * As of PHP 8.1.0, a class which implements Serializable without also implementing __serialize() and __unserialize() will generate a deprecation warning.
+     * @see https://php.watch/versions/8.1/serializable-deprecated
+     *
+     * @param array $array
+     */
+    public function __unserialize(array $array)
+    {
         foreach ($array as $name => $values) {
             $this->$name = $values;
         }

--- a/lib/Doctrine/Connection/Profiler.php
+++ b/lib/Doctrine/Connection/Profiler.php
@@ -134,6 +134,7 @@ class Doctrine_Connection_Profiler implements Doctrine_Overloadable, IteratorAgg
      *
      * @return ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->events);
@@ -144,6 +145,7 @@ class Doctrine_Connection_Profiler implements Doctrine_Overloadable, IteratorAgg
      * 
      * @return integer
      */
+    #[\ReturnTypeWillChange]
     public function count() 
     {
         return count($this->events);

--- a/lib/Doctrine/Connection/Statement.php
+++ b/lib/Doctrine/Connection/Statement.php
@@ -300,7 +300,7 @@ class Doctrine_Connection_Statement implements Doctrine_Adapter_Statement_Interf
      */
     public function fetch($fetchMode = Doctrine_Core::FETCH_BOTH,
                           $cursorOrientation = Doctrine_Core::FETCH_ORI_NEXT,
-                          $cursorOffset = null)
+                          $cursorOffset = 0)
     {
         $event = new Doctrine_Event($this, Doctrine_Event::STMT_FETCH, $this->getQuery());
 

--- a/lib/Doctrine/Formatter.php
+++ b/lib/Doctrine/Formatter.php
@@ -270,6 +270,6 @@ class Doctrine_Formatter extends Doctrine_Connection_Module
     public function getTableName($table)
     {
         $format = $this->conn->getAttribute(Doctrine_Core::ATTR_TBLNAME_FORMAT);
-        return sprintf($format, str_replace(sprintf($format, null), null, $table));
+        return sprintf($format, str_replace(sprintf($format, ''), '', $table));
     }
 }

--- a/lib/Doctrine/Hydrator/Graph.php
+++ b/lib/Doctrine/Hydrator/Graph.php
@@ -48,6 +48,11 @@ abstract class Doctrine_Hydrator_Graph extends Doctrine_Hydrator_Abstract
         return isset($this->_queryComponents[$alias]['map']) ? $this->_queryComponents[$alias]['map'] : null;
     }
 
+    protected function _rtrim($value)
+    {
+        return is_string($value) ? rtrim($value) : $value;
+    }
+
     public function hydrateResultSet($stmt)
     {
         // Used variables during hydration
@@ -120,7 +125,7 @@ abstract class Doctrine_Hydrator_Graph extends Doctrine_Hydrator_Abstract
             $table = $this->_queryComponents[$rootAlias]['table'];
         
             if ($table->getConnection()->getAttribute(Doctrine_Core::ATTR_PORTABILITY) & Doctrine_Core::PORTABILITY_RTRIM) {
-                array_map('rtrim', $data);
+                array_map(array($this, '_rtrim'), $data);
             }
         
             $id = $idTemplate; // initialize the id-memory

--- a/lib/Doctrine/Manager.php
+++ b/lib/Doctrine/Manager.php
@@ -407,6 +407,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
 
         // silence any warnings
         $parts = @parse_url($dsn);
+        $parts = $parts !== false ? $parts : array();
 
         $names = array('dsn', 'scheme', 'host', 'port', 'user', 'pass', 'path', 'query', 'fragment');
 
@@ -635,6 +636,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
      *
      * @return integer
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_connections);
@@ -645,6 +647,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
      *
      * @return ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->_connections);

--- a/lib/Doctrine/Migration/Builder.php
+++ b/lib/Doctrine/Migration/Builder.php
@@ -75,7 +75,7 @@ class Doctrine_Migration_Builder extends Doctrine_Builder
         if ($migrationsPath instanceof Doctrine_Migration) {
             $this->setMigrationsPath($migrationsPath->getMigrationClassesDirectory());
             $this->migration = $migrationsPath;
-        } else if (is_dir($migrationsPath)) {
+        } else if ($migrationsPath !== null && is_dir($migrationsPath)) {
             $this->setMigrationsPath($migrationsPath);
             $this->migration = new Doctrine_Migration($migrationsPath);
         }

--- a/lib/Doctrine/Migration/Diff.php
+++ b/lib/Doctrine/Migration/Diff.php
@@ -318,7 +318,9 @@ class Doctrine_Migration_Diff
                 $info[$key] = $this->_cleanModelInformation($value);
             }
             return $info;
-        } else {
+        }
+
+        if (is_string($info)) {
             $find = array(
                 self::$_toPrefix,
                 self::$_fromPrefix,
@@ -327,8 +329,10 @@ class Doctrine_Migration_Diff
                 Doctrine_Inflector::tableize(self::$_toPrefix),
                 Doctrine_Inflector::tableize(self::$_fromPrefix)
             );
-            return str_replace($find, null, $info);
+            return str_replace($find, '', $info);
         }
+
+        return $info;
     }
 
     /**

--- a/lib/Doctrine/Node.php
+++ b/lib/Doctrine/Node.php
@@ -160,6 +160,7 @@ class Doctrine_Node implements IteratorAggregate
      * @param string $type                      type of iterator (Pre | Post | Level)
      * @param array $options                    options
      */
+    #[\ReturnTypeWillChange]
     public function getIterator($type = null, $options = null)
     {
         if ($type === null) {

--- a/lib/Doctrine/Parser/Xml.php
+++ b/lib/Doctrine/Parser/Xml.php
@@ -86,7 +86,10 @@ class Doctrine_Parser_Xml extends Doctrine_Parser
                 if (strcasecmp($charset, 'utf-8') !== 0 && strcasecmp($charset, 'utf8') !== 0) {
                     $value = iconv($charset, 'UTF-8', $value);
                 }
-                $value = htmlspecialchars($value, ENT_COMPAT, 'UTF-8');
+                if (is_string($value)) {
+                    $value = htmlspecialchars($value, ENT_COMPAT, 'UTF-8');
+                }
+
                 $xml->addChild($key, $value);
             }
         }
@@ -116,7 +119,7 @@ class Doctrine_Parser_Xml extends Doctrine_Parser
      *
      * Prepare simple xml to array for return
      *
-     * @param  string $simpleXml 
+     * @param  string $simpleXml
      * @return array  $return
      */
     public function prepareData($simpleXml)

--- a/lib/Doctrine/Parser/sfYaml/sfYamlInline.php
+++ b/lib/Doctrine/Parser/sfYaml/sfYamlInline.php
@@ -98,7 +98,7 @@ class sfYamlInline
         return 'true';
       case false === $value:
         return 'false';
-      case ctype_digit($value):
+      case ctype_digit((string)$value):
         return is_string($value) ? "'$value'" : (int) $value;
       case is_numeric($value):
         return is_infinite($value) ? str_ireplace('INF', '.Inf', strval($value)) : (is_string($value) ? "'$value'" : $value);

--- a/lib/Doctrine/Query.php
+++ b/lib/Doctrine/Query.php
@@ -2502,6 +2502,7 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
      * @param array $params        an array of prepared statement parameters
      * @return integer             the count of this query
      */
+    #[\ReturnTypeWillChange]
     public function count($params = array())
     {
         $q = $this->getCountSqlQuery($params);

--- a/lib/Doctrine/Record.php
+++ b/lib/Doctrine/Record.php
@@ -201,7 +201,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      *
      * @var array
      */
-    protected $_invokedSaveHooks = false;
+    protected $_invokedSaveHooks = array();
 
     /**
      * @var integer $index                  this index is used for creating object identifiers
@@ -887,18 +887,28 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      */
     public function serialize()
     {
+        return serialize($this->__serialize());
+    }
+
+    /**
+     * As of PHP 8.1.0, a class which implements Serializable without also implementing __serialize() and __unserialize() will generate a deprecation warning.
+     * @see https://php.watch/versions/8.1/serializable-deprecated
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
         $event = new Doctrine_Event($this, Doctrine_Event::RECORD_SERIALIZE);
 
         $this->preSerialize($event);
         $this->getTable()->getRecordListener()->preSerialize($event);
 
         $vars = $this->getSerializeVars();
-        $str = serialize($vars);
 
         $this->postSerialize($event);
         $this->getTable()->getRecordListener()->postSerialize($event);
 
-        return $str;
+        return $vars;
     }
 
     /**
@@ -910,8 +920,19 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      */
     public function unserialize($serialized)
     {
+        $this->__unserialize(unserialize($serialized));
+    }
+
+    /**
+     * As of PHP 8.1.0, a class which implements Serializable without also implementing __serialize() and __unserialize() will generate a deprecation warning.
+     * @see https://php.watch/versions/8.1/serializable-deprecated
+     *
+     * @param array $array
+     */
+    public function __unserialize(array $array)
+    {
         $event = new Doctrine_Event($this, Doctrine_Event::RECORD_UNSERIALIZE);
-        
+
         $manager    = Doctrine_Manager::getInstance();
         $connection = $manager->getConnectionForComponent(get_class($this));
 
@@ -919,8 +940,6 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
         
         $this->preUnserialize($event);
         $this->getTable()->getRecordListener()->preUnserialize($event);
-
-        $array = unserialize($serialized);
 
         foreach($array as $k => $v) {
             $this->$k = $v;
@@ -1612,7 +1631,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
             return $old * 100 != $new * 100;
         } else if (in_array($type, array('integer', 'int')) && is_numeric($old) && is_numeric($new)) {
             return $old != $new;
-        } else if ($type == 'timestamp' || $type == 'date') {
+        } else if (($type == 'timestamp' || $type == 'date') && is_string($old) && is_string($new)) {
             $oldStrToTime = strtotime($old);
             $newStrToTime = strtotime($new);
             if ($oldStrToTime && $newStrToTime) {
@@ -1960,6 +1979,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      *
      * @return integer          the number of columns in this record
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_data);
@@ -2272,6 +2292,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * implements IteratorAggregate interface
      * @return Doctrine_Record_Iterator     iterator through data
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new Doctrine_Record_Iterator($this);

--- a/lib/Doctrine/Record/Iterator.php
+++ b/lib/Doctrine/Record/Iterator.php
@@ -68,6 +68,7 @@ class Doctrine_Record_Iterator extends ArrayIterator
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $value = parent::current();

--- a/lib/Doctrine/Record/Listener.php
+++ b/lib/Doctrine/Record/Listener.php
@@ -79,7 +79,7 @@ class Doctrine_Record_Listener implements Doctrine_Record_Listener_Interface
 
         return null; 
     }
-	
+
     public function preSerialize(Doctrine_Event $event)
     { }
 

--- a/lib/Doctrine/Relation.php
+++ b/lib/Doctrine/Relation.php
@@ -170,11 +170,13 @@ abstract class Doctrine_Relation implements ArrayAccess
         return $this->definition['equal'];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->definition[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (isset($this->definition[$offset])) {
@@ -184,6 +186,7 @@ abstract class Doctrine_Relation implements ArrayAccess
         return null;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (isset($this->definition[$offset])) {
@@ -191,6 +194,7 @@ abstract class Doctrine_Relation implements ArrayAccess
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->definition[$offset] = false;

--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -1956,6 +1956,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
      *
      * @return integer number of records in the table
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->createQuery()->count();

--- a/lib/Doctrine/Table/Repository.php
+++ b/lib/Doctrine/Table/Repository.php
@@ -102,6 +102,7 @@ class Doctrine_Table_Repository implements Countable, IteratorAggregate
      * Doctrine_Registry implements interface Countable
      * @return integer                      the number of records this registry has
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->registry);
@@ -138,6 +139,7 @@ class Doctrine_Table_Repository implements Countable, IteratorAggregate
      * getIterator
      * @return ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->registry);

--- a/lib/Doctrine/Task.php
+++ b/lib/Doctrine/Task.php
@@ -56,7 +56,7 @@ abstract class Doctrine_Task
         $taskName = $this->getTaskName();
 
         //Derive the task name only if it wasn't entered at design-time
-        if (! strlen($taskName)) {
+        if ($taskName === null || ! strlen($taskName)) {
             $taskName = self::deriveTaskName(get_class($this));
         }
 

--- a/lib/Doctrine/Validator.php
+++ b/lib/Doctrine/Validator.php
@@ -127,6 +127,8 @@ class Doctrine_Validator extends Doctrine_Locator_Injectable
      */
     public static function getStringLength($string)
     {
+        $string = (string)$string;
+
         if (function_exists('mb_strlen')) {
             return mb_strlen($string, 'utf8');
         } else {

--- a/lib/Doctrine/Validator/ErrorStack.php
+++ b/lib/Doctrine/Validator/ErrorStack.php
@@ -148,6 +148,7 @@ class Doctrine_Validator_ErrorStack extends Doctrine_Access implements Countable
      *
      * @return unknown
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->_errors);
@@ -163,6 +164,7 @@ class Doctrine_Validator_ErrorStack extends Doctrine_Access implements Countable
      *
      * @return integer
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_errors);

--- a/lib/Doctrine/Validator/Exception.php
+++ b/lib/Doctrine/Validator/Exception.php
@@ -51,11 +51,13 @@ class Doctrine_Validator_Exception extends Doctrine_Exception implements Countab
         return $this->invalid;
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->invalid);
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->invalid);

--- a/lib/Doctrine/Validator/Notblank.php
+++ b/lib/Doctrine/Validator/Notblank.php
@@ -41,6 +41,14 @@ class Doctrine_Validator_Notblank extends Doctrine_Validator_Driver
      */
     public function validate($value)
     {
-        return (trim($value) !== '' && $value !== null);
+        if (is_null($value)) {
+            return false;
+        }
+
+        if (is_string($value) && trim($value) === '') {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/tests/EventListenerTestCase.php
+++ b/tests/EventListenerTestCase.php
@@ -192,6 +192,7 @@ class Doctrine_EventListener_TestLogger implements Doctrine_Overloadable, Counta
     public function getAll() {
         return $this->messages;
     }
+    #[\ReturnTypeWillChange]
     public function count() {
         return count($this->messages);
     }

--- a/tests/HydrateTestCase.php
+++ b/tests/HydrateTestCase.php
@@ -86,7 +86,7 @@ class HydrationListener extends Doctrine_Record_Listener
     public function postHydrate(Doctrine_Event $event)
     {
     	foreach ($event->data as $key => $value) {
-            $event->data[$key] = strtoupper($value);
+            $event->data[$key] = is_string($value) ? strtoupper($value) : $value;
         }
     }
 }

--- a/tests/Record/ZeroValuesTestCase.php
+++ b/tests/Record/ZeroValuesTestCase.php
@@ -53,7 +53,9 @@ class Doctrine_Record_ZeroValues_TestCase extends Doctrine_UnitTestCase
     {
         $users = $this->dbh->query('SELECT * FROM zero_value_test')->fetchAll(PDO::FETCH_ASSOC);
 
-        $this->assertIdentical($users[0]['is_super_admin'], '0');
+        // SQLite: In PHP 8.1, the mapping of database types to PHP's native types has been greatly improved.
+        // For instance, it has been made sure that an INT value from an SQL result is translated to a PHP integer value where it had been a string previously.
+        $this->assertIdentical($users[0]['is_super_admin'], PHP_VERSION_ID >= 80100 ? 0 : '0');
     }
 
     public function testZeroValuesMaintained2()

--- a/tests/Ticket/1254TestCase.php
+++ b/tests/Ticket/1254TestCase.php
@@ -51,7 +51,7 @@ class Doctrine_Ticket_1254_TestCase extends Doctrine_UnitTestCase
             $x = new RelX();
 	        $x->name = "x $i";
 		    $x->category = $cats[$i % 2];
-		    $x->set('created_at', strftime("%Y-%m-%d %H:%M:%S", $age));
+		    $x->set('created_at', date("Y-m-d H:i:s", $age));
 	        $x->save();
         
 	        for ($j = 0; $j < 10; $j++) {

--- a/tests/Ticket/982TestCase.php
+++ b/tests/Ticket/982TestCase.php
@@ -35,30 +35,32 @@ class Doctrine_Ticket_982_TestCase extends Doctrine_UnitTestCase
         $this->conn->getTable('T982_MyModel')->clear();
         
         $myModelZero = $this->conn->getTable('T982_MyModel')->find(0);
-        
-		$this->assertIdentical($myModelZero->id, '0');
-		$this->assertIdentical($myModelZero->parentid, '0');
+
+        // SQLite: In PHP 8.1, the mapping of database types to PHP's native types has been greatly improved.
+        // For instance, it has been made sure that an INT value from an SQL result is translated to a PHP integer value where it had been a string previously.
+		$this->assertIdentical($myModelZero->id, PHP_VERSION_ID >= 80100 ? 0 : '0');
+		$this->assertIdentical($myModelZero->parentid, PHP_VERSION_ID >= 80100 ? 0 : '0');
 		$this->assertTrue($myModelZero->parent->exists());
-		$this->assertTrue(ctype_digit($myModelZero->parent->id));
+		$this->assertTrue(ctype_digit((string)$myModelZero->parent->id));
 		$this->assertIdentical($myModelZero, $myModelZero->parent);
-		$this->assertIdentical($myModelZero->parent->id, '0');
-		$this->assertIdentical($myModelZero->parent->parentid, '0');		
+		$this->assertIdentical($myModelZero->parent->id, PHP_VERSION_ID >= 80100 ? 0 : '0');
+		$this->assertIdentical($myModelZero->parent->parentid, PHP_VERSION_ID >= 80100 ? 0 : '0');
         
         $myModelOne = $this->conn->getTable('T982_MyModel')->find(1);
-        
-        $this->assertIdentical($myModelOne->id, '1');
-		$this->assertIdentical($myModelOne->parentid, '0');
+
+        $this->assertIdentical($myModelOne->id, PHP_VERSION_ID >= 80100 ? 1 : '1');
+		$this->assertIdentical($myModelOne->parentid, PHP_VERSION_ID >= 80100 ? 0 : '0');
 		$this->assertTrue($myModelOne->parent->exists());
-		$this->assertTrue(ctype_digit($myModelOne->parent->id));
-		$this->assertIdentical($myModelOne->parent->id, '0');
-		$this->assertIdentical($myModelOne->parent->parentid, '0');
+		$this->assertTrue(ctype_digit((string)$myModelOne->parent->id));
+		$this->assertIdentical($myModelOne->parent->id, PHP_VERSION_ID >= 80100 ? 0 : '0');
+		$this->assertIdentical($myModelOne->parent->parentid, PHP_VERSION_ID >= 80100 ? 0 : '0');
 		
 		$myModelTwo = $this->conn->getTable('T982_MyModel')->find(2);
 
-        $this->assertIdentical($myModelTwo->id, '2');
-		$this->assertIdentical($myModelTwo->parentid, '1');
-		$this->assertIdentical($myModelTwo->parent->id, '1');
-		$this->assertIdentical($myModelTwo->parent->parentid, '0');
+        $this->assertIdentical($myModelTwo->id, PHP_VERSION_ID >= 80100 ? 2 : '2');
+		$this->assertIdentical($myModelTwo->parentid, PHP_VERSION_ID >= 80100 ? 1 : '1');
+		$this->assertIdentical($myModelTwo->parent->id, PHP_VERSION_ID >= 80100 ? 1 : '1');
+		$this->assertIdentical($myModelTwo->parent->parentid, PHP_VERSION_ID >= 80100 ? 0 : '0');
 		
    }
 }


### PR DESCRIPTION
- added `#[\ReturnTypeWillChange]` attribute where necessary https://php.watch/versions/8.1/ReturnTypeWillChange
- https://php.watch/versions/8.1/serializable-deprecated
- fixes for deprecations and mismatching types of parameter values
- SQLite: In PHP 8.1, the mapping of database types to PHP's native types has been greatly improved.
For instance, it has been made sure that an INT value from an SQL result is translated to a PHP integer value where it had been a string previously.