### PR TITLE
php 8.2 compatibility fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,14 +13,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
-        include:
-          - php: '8.2'
-            allow-failure: true
+        php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.3.4 (2022-10-17)
+- php 8.2 compatibility fixes [#12](https://github.com/ovos/doctrine1/pull/12)
+- php 8.1 compatibility fixes [#11](https://github.com/ovos/doctrine1/pull/11)
+
 1.3.3 (2022-10-04)
 ------------------
 - php 8.0 compatibility fixes [#8](https://github.com/ovos/doctrine1/pull/8)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Doctrine 1
 
 [![Build Status](https://travis-ci.com/ovos/doctrine1.svg?branch=master)](https://travis-ci.com/ovos/doctrine1)
 
-This is a fork of [doctrine/doctrine1](https://github.com/doctrine/doctrine1), adjusted for compatibility with php 5.3-8.0
+This is a fork of [doctrine/doctrine1](https://github.com/doctrine/doctrine1), adjusted for compatibility with php 5.3-8.2
 and mysql 5.7 and 8.0. Tested only with mysql.
 
 It will be maintained as long as we are using it.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "ovos/doctrine1",
     "type": "library",
-    "description": "PHP 5 Doctrine1 Object Relational Mapper (ORM)",
+    "description": "Doctrine v1, Database ORM, PHP 5.3-8.2 compatible",
     "keywords": [
         "php",
         "doctrine1",

--- a/lib/Doctrine/Cli/AnsiColorFormatter.php
+++ b/lib/Doctrine/Cli/AnsiColorFormatter.php
@@ -115,7 +115,7 @@ class Doctrine_Cli_AnsiColorFormatter extends Doctrine_Cli_Formatter
     {
         $width = 9 + strlen($this->format('', 'INFO'));
 
-        return sprintf(">> %-${width}s %s", $this->format($section, 'INFO'), $this->excerpt($text, $size));
+        return sprintf(">> %-{$width}s %s", $this->format($section, 'INFO'), $this->excerpt($text, $size));
     }
 
     /**

--- a/lib/Doctrine/Connection.php
+++ b/lib/Doctrine/Connection.php
@@ -1255,7 +1255,6 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
     public function evictTables()
     {
         $this->tables = array();
-        $this->exported = array();
     }
 
     /**

--- a/lib/Doctrine/Hydrator/Graph.php
+++ b/lib/Doctrine/Hydrator/Graph.php
@@ -36,6 +36,7 @@
 abstract class Doctrine_Hydrator_Graph extends Doctrine_Hydrator_Abstract
 {
     protected $_tables = array();
+    protected $_rootAlias;
 
     /**
      * Gets the custom field used for indexing for the specified component alias.

--- a/lib/Doctrine/Import/Builder.php
+++ b/lib/Doctrine/Import/Builder.php
@@ -88,6 +88,11 @@ class Doctrine_Import_Builder extends Doctrine_Builder
     protected $_generateTableClasses = false;
 
     /**
+     * @var boolean
+     */
+    protected $_generateAccessors = false;
+
+    /**
      * Prefix to use for generated base classes
      *
      * @var string

--- a/lib/Doctrine/Query.php
+++ b/lib/Doctrine/Query.php
@@ -169,11 +169,6 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
     protected $_parsers = array();
 
     /**
-     * @var array $_pendingJoinConditions    an array containing pending joins
-     */
-    protected $_pendingJoinConditions = array();
-
-    /**
      * @var array
      */
     protected $_expressionMap = array();

--- a/lib/Doctrine/Query/Abstract.php
+++ b/lib/Doctrine/Query/Abstract.php
@@ -280,6 +280,11 @@ abstract class Doctrine_Query_Abstract
     protected $_preQueried = false;
 
     /**
+     * @var array $_pendingJoinConditions    an array containing pending joins
+     */
+    protected $_pendingJoinConditions = array();
+
+    /**
      * Fix for http://www.doctrine-project.org/jira/browse/DC-701
      *
      * @var bool Boolean variable for whether the limitSubquery method of accessing tables via a many relationship should be used.

--- a/lib/Doctrine/RawSql.php
+++ b/lib/Doctrine/RawSql.php
@@ -59,7 +59,7 @@ class Doctrine_RawSql extends Doctrine_Query_Abstract
 
     protected function clear()
     {
-        $this->_preQuery = false;
+        $this->_preQueried = false;
         $this->_pendingJoinConditions = array();
     }
 

--- a/lib/Doctrine/Sequence.php
+++ b/lib/Doctrine/Sequence.php
@@ -34,6 +34,11 @@
 class Doctrine_Sequence extends Doctrine_Connection_Module
 {
     /**
+     * @var array
+     */
+    protected $warnings = array();
+
+    /**
      * Returns the next free id of a sequence
      *
      * @param string $seqName   name of the sequence

--- a/lib/Doctrine/Task/BuildAll.php
+++ b/lib/Doctrine/Task/BuildAll.php
@@ -38,7 +38,12 @@ class Doctrine_Task_BuildAll extends Doctrine_Task
     
     protected $models,
               $tables;
-    
+
+    /**
+     * @var Doctrine_Task_CreateDb
+     */
+    protected $createDb;
+
     public function __construct($dispatcher = null)
     {
         parent::__construct($dispatcher);

--- a/lib/Doctrine/Task/BuildAllLoad.php
+++ b/lib/Doctrine/Task/BuildAllLoad.php
@@ -35,7 +35,17 @@ class Doctrine_Task_BuildAllLoad extends Doctrine_Task
     public $description          =   'Calls build-all, and load-data',
            $requiredArguments    =   array(),
            $optionalArguments    =   array();
-    
+
+    /**
+     * @var Doctrine_Task_BuildAll
+     */
+    protected $buildAll;
+
+    /**
+     * @var Doctrine_Task_LoadData
+     */
+    protected $loadData;
+
     public function __construct($dispatcher = null)
     {
         parent::__construct($dispatcher);

--- a/lib/Doctrine/Task/BuildAllReload.php
+++ b/lib/Doctrine/Task/BuildAllReload.php
@@ -35,7 +35,17 @@ class Doctrine_Task_BuildAllReload extends Doctrine_Task
     public $description          =   'Calls rebuild-db and load-data',
            $requiredArguments    =   array(),
            $optionalArguments    =   array();
-    
+
+    /**
+     * @var Doctrine_Task_RebuildDb
+     */
+    protected $rebuildDb;
+
+    /**
+     * @var Doctrine_Task_LoadData
+     */
+    protected $loadData;
+
     public function __construct($dispatcher = null)
     {
         parent::__construct($dispatcher);

--- a/lib/Doctrine/Task/RebuildDb.php
+++ b/lib/Doctrine/Task/RebuildDb.php
@@ -35,7 +35,22 @@ class Doctrine_Task_RebuildDb extends Doctrine_Task
     public $description          =   'Drops and re-creates databases',
            $requiredArguments    =   array(),
            $optionalArguments    =   array();
-    
+
+    /**
+     * @var Doctrine_Task_DropDb
+     */
+    protected $dropDb;
+
+    /**
+     * @var Doctrine_Task_CreateDb
+     */
+    protected $createDb;
+
+    /**
+     * @var Doctrine_Task_CreateTables
+     */
+    protected $createTables;
+
     public function __construct($dispatcher = null)
     {
         parent::__construct($dispatcher);

--- a/tests/AuditLogTestCase.php
+++ b/tests/AuditLogTestCase.php
@@ -32,6 +32,10 @@
  */
 class Doctrine_AuditLog_TestCase extends Doctrine_UnitTestCase
 {
+    /**
+     * @var Doctrine_Connection_Profiler
+     */
+    private $profiler;
 
     public function prepareData()
     { }

--- a/tests/Cache/DbTestCase.php
+++ b/tests/Cache/DbTestCase.php
@@ -33,6 +33,11 @@
  */
 class Doctrine_Cache_Db_TestCase extends Doctrine_Cache_Abstract_TestCase
 {
+    /**
+     * @var Doctrine_Cache_Db
+     */
+    private $cache;
+
     public function setUp()
     {
         parent::setUp();

--- a/tests/Connection/CustomTestCase.php
+++ b/tests/Connection/CustomTestCase.php
@@ -32,6 +32,16 @@
  */
 class Doctrine_Connection_Custom_TestCase extends Doctrine_UnitTestCase 
 {
+    /**
+     * @var Doctrine_Connection
+     */
+    protected $_conn;
+
+    /**
+     * @var Doctrine_Adapter_Interface
+     */
+    protected $_dbh;
+
     public function setUp()
     {
         $manager = Doctrine_Manager::getInstance();

--- a/tests/Connection/ProfilerTestCase.php
+++ b/tests/Connection/ProfilerTestCase.php
@@ -33,6 +33,11 @@
  */
 class Doctrine_Connection_Profiler_TestCase extends Doctrine_UnitTestCase 
 {
+    /**
+     * @var Doctrine_Connection_Profiler
+     */
+    private $profiler;
+
     public function prepareTables()
     {}
     public function prepareData() 

--- a/tests/Db/ProfilerTestCase.php
+++ b/tests/Db/ProfilerTestCase.php
@@ -33,6 +33,11 @@
  */
 class Doctrine_Connection_Profiler_TestCase extends Doctrine_UnitTestCase 
 {
+    /**
+     * @var Doctrine_Connection_Profiler
+     */
+    protected $profiler;
+
     public function prepareTables()
     {}
     public function prepareData() 

--- a/tests/DoctrineTest/Doctrine_UnitTestCase.php
+++ b/tests/DoctrineTest/Doctrine_UnitTestCase.php
@@ -54,8 +54,12 @@ class Doctrine_UnitTestCase extends UnitTestCase
     protected $transaction;
     protected $_name;
 
-
     protected $init = false;
+
+    protected $query;
+    protected $exc;
+    protected $sequence;
+    protected $import;
 
     public function getName()
     {

--- a/tests/DoctrineTest/GroupTest.php
+++ b/tests/DoctrineTest/GroupTest.php
@@ -5,6 +5,7 @@ class GroupTest extends UnitTestCase
     protected $_name;
     protected $_title;
     protected $_onlyRunFailed = false;
+    protected $_formatter;
 
     public function __construct($title, $name)
     {

--- a/tests/ManagerTestCase.php
+++ b/tests/ManagerTestCase.php
@@ -31,6 +31,26 @@
  * @version     $Revision$
  */
 class Doctrine_Manager_TestCase extends Doctrine_UnitTestCase {
+    /**
+     * @var string
+     */
+    protected $conn1_database;
+
+    /**
+     * @var string
+     */
+    protected $conn2_database;
+
+    /**
+     * @var Doctrine_Connection
+     */
+    protected $conn1;
+
+    /**
+     * @var Doctrine_Connection
+     */
+    protected $conn2;
+
     public function testGetInstance() {
         $this->assertTrue(Doctrine_Manager::getInstance() instanceOf Doctrine_Manager);
     }

--- a/tests/Record/FromArrayTestCase.php
+++ b/tests/Record/FromArrayTestCase.php
@@ -32,6 +32,8 @@
  */
 class Doctrine_Record_FromArray_TestCase extends Doctrine_UnitTestCase
 {
+    private $previous_group;
+
     public function prepareTables()
     {
         parent::prepareTables();

--- a/tests/Record/SynchronizeTestCase.php
+++ b/tests/Record/SynchronizeTestCase.php
@@ -32,6 +32,8 @@
  */
 class Doctrine_Record_Synchronize_TestCase extends Doctrine_UnitTestCase
 {
+    private $previous_group;
+
     public function prepareTables()
     {
         parent::prepareTables();

--- a/tests/Relation/OrderByTestCase.php
+++ b/tests/Relation/OrderByTestCase.php
@@ -32,6 +32,11 @@
  */
 class Doctrine_Relation_OrderBy_TestCase extends Doctrine_UnitTestCase 
 {
+    /**
+     * @var Doctrine_Connection_Profiler
+     */
+    private $profiler;
+
     public function prepareTables()
     {
         $this->profiler = new Doctrine_Connection_Profiler();

--- a/tests/Search/FileTestCase.php
+++ b/tests/Search/FileTestCase.php
@@ -32,6 +32,11 @@
  */
 class Doctrine_Search_File_TestCase extends Doctrine_UnitTestCase
 {
+    /**
+     * @var Doctrine_Search_File
+     */
+    private $_search;
+
     public function prepareData()
     { }
     public function prepareTables()

--- a/tests/TableTestCase.php
+++ b/tests/TableTestCase.php
@@ -142,9 +142,9 @@ class Doctrine_Table_TestCase extends Doctrine_UnitTestCase
 
     public function testSetSequenceName()
     {
-        $this->objTable->sequenceName = 'test-seq';
+        $this->objTable->setOption('sequenceName', 'test-seq');
         $this->assertEqual($this->objTable->sequenceName, 'test-seq');
-        $this->objTable->sequenceName = null;
+        $this->objTable->setOption('sequenceName', null);
     }
 
     public function testCreate() 

--- a/tests/Ticket/1106TestCase.php
+++ b/tests/Ticket/1106TestCase.php
@@ -32,6 +32,8 @@
  */
 class Doctrine_Ticket_1106_TestCase extends Doctrine_UnitTestCase
 {
+    private $user_id;
+
     public function prepareTables()
     {
         parent::prepareTables();

--- a/tests/Ticket/1131TestCase.php
+++ b/tests/Ticket/1131TestCase.php
@@ -32,6 +32,9 @@
  */
 class Doctrine_Ticket_1131_TestCase extends Doctrine_UnitTestCase
 {
+    private $role_one;
+    private $role_two;
+
     public function prepareTables()
     {
         //$this->tables = array();

--- a/tests/Ticket/1436TestCase.php
+++ b/tests/Ticket/1436TestCase.php
@@ -32,6 +32,10 @@
  */
 class Doctrine_Ticket_1436_TestCase extends Doctrine_UnitTestCase
 {
+    private $group_one;
+    private $group_two;
+    private $group_three;
+
     public function prepareTables()
     {
         parent::prepareTables();

--- a/tests/Ticket/1992TestCase.php
+++ b/tests/Ticket/1992TestCase.php
@@ -32,6 +32,21 @@
  */
 class Doctrine_Ticket_1992_TestCase extends Doctrine_UnitTestCase 
 {
+    /**
+     * @var Ticket_1992_Person
+     */
+    private $person;
+
+    /**
+     * @var Ticket_1992_Profile
+     */
+    private $profile1;
+
+    /**
+     * @var Ticket_1992_Profile
+     */
+    private $profile2;
+
     public function prepareTables()
     {
         $this->tables[] = 'Ticket_1992_Person';

--- a/tests/Ticket/2158TestCase.php
+++ b/tests/Ticket/2158TestCase.php
@@ -2,6 +2,11 @@
 
 class Doctrine_Ticket_2158_TestCase extends Doctrine_UnitTestCase
 {
+    /**
+     * @var T2158_Model1
+     */
+    private $myModel;
+
     public function prepareTables()
     {
         $this->tables[] = "T2158_Model1";

--- a/tests/Ticket/982TestCase.php
+++ b/tests/Ticket/982TestCase.php
@@ -3,7 +3,17 @@
  * Test to ensure LocalKey Relations allow 0 for id value
  */
 class Doctrine_Ticket_982_TestCase extends Doctrine_UnitTestCase
-{    
+{
+    /**
+     * @var T982_MyModel
+     */
+    private $myModelOne;
+
+    /**
+     * @var T982_MyModel
+     */
+    private $myModelTwo;
+
     public function prepareTables()
     {
         $this->tables = array();


### PR DESCRIPTION
- fix many deprecation notices, i.a. 'Creation of dynamic property is deprecated' 
- moved few properties around, adjusted wrong usages