### PR TITLE
PHP 8.4: Implicitly nullable parameter declarations deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,19 @@
         {"name": "Konsta Vesterinen", "email": "kvesteri@cc.hut.fi"},
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"}
     ],
+    "repositories": [
+        {
+            "type": "git",
+            "url": "git@github.com:zf1s/compat.git"
+        }
+    ],
     "replace": {
         "doctrine/doctrine1": "*"
     },
     "require": {
         "php": ">=5.3.3",
-        "ext-pdo": "*"
+        "ext-pdo": "*",
+        "zf1s/compat": "^1.0"
     },
     "autoload": {
         "psr-0": {

--- a/lib/Doctrine/Cli.php
+++ b/lib/Doctrine/Cli.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /*
  *  $Id: Cli.php 2761 2007-10-07 23:42:29Z zYne $
  *
@@ -71,11 +74,14 @@ class Doctrine_Cli
     /**
      * __construct
      *
-     * @param array [$config=array()]
+     * @param array|null [$config=array()]
      * @param object|null [$formatter=null] Doctrine_Cli_Formatter
      */
-    public function __construct(array $config = array(), Doctrine_Cli_Formatter $formatter = null)
+    public function __construct($config = array(), $formatter = null)
     {
+        Types::isNullable('config', $config, 'array');
+        Types::isNullable('formatter', $formatter, 'Doctrine_Cli_Formatter');
+
         $this->setConfig($config);
         $this->setFormatter($formatter ? $formatter : new Doctrine_Cli_AnsiColorFormatter());
         $this->includeAndRegisterTaskClasses();

--- a/lib/Doctrine/Collection.php
+++ b/lib/Doctrine/Collection.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /*
  *  $Id: Collection.php 7686 2010-08-24 16:54:40Z jwage $
  *
@@ -137,7 +140,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      * @param array $data
      * @return Doctrine_Collection
      */
-    public function setData(array $data) 
+    public function setData(array $data)
     {
         $this->data = $data;
     }
@@ -188,7 +191,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     {
         $this->__unserialize(unserialize($serialized));
     }
-    
+
     /**
      * As of PHP 8.1.0, a class which implements Serializable without also implementing __serialize() and __unserialize() will generate a deprecation warning.
      * @see https://php.watch/versions/8.1/serializable-deprecated
@@ -225,7 +228,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     public function setKeyColumn($column)
     {
         $this->keyColumn = $column;
-        
+
         return $this;
     }
 
@@ -299,7 +302,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
         $this->reference = $record;
         $this->relation  = $relation;
 
-        if ($relation instanceof Doctrine_Relation_ForeignKey || 
+        if ($relation instanceof Doctrine_Relation_ForeignKey ||
                 $relation instanceof Doctrine_Relation_LocalKey) {
             $this->referenceField = $relation->getForeignFieldName();
 
@@ -355,7 +358,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     /**
      * Search a Doctrine_Record instance
      *
-     * @param string $Doctrine_Record 
+     * @param string $Doctrine_Record
      * @return void
      */
     public function search(Doctrine_Record $record)
@@ -396,7 +399,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
             if ($key === null) {
                 $this->data[] = $record;
             } else {
-                $this->data[$key] = $record;      	
+                $this->data[$key] = $record;
             }
 
             if (isset($this->keyColumn)) {
@@ -522,10 +525,10 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
 
         return true;
     }
-    
+
     /**
      * Merges collection into $this and returns merged collection
-     * 
+     *
      * @param Doctrine_Collection $coll
      * @return Doctrine_Collection
      */
@@ -533,15 +536,15 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     {
         $localBase = $this->getTable()->getComponentName();
         $otherBase = $coll->getTable()->getComponentName();
-        
+
         if ($otherBase != $localBase && !is_subclass_of($otherBase, $localBase) ) {
             throw new Doctrine_Collection_Exception("Can't merge collections with incompatible record types");
         }
-        
+
         foreach ($coll->getData() as $record) {
             $this->add($record);
         }
-        
+
         return $this;
     }
 
@@ -685,7 +688,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     public function takeSnapshot()
     {
         $this->_snapshot = $this->data;
-        
+
         return $this;
     }
 
@@ -710,7 +713,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      *
      * @return Doctrine_Collection
      */
-    public function processDiff() 
+    public function processDiff()
     {
         foreach (array_udiff($this->_snapshot, $this->data, array($this, "compareRecords")) as $record) {
             $record->delete();
@@ -728,20 +731,20 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     {
         $data = array();
         foreach ($this as $key => $record) {
-            
+
             $key = $prefixKey ? get_class($record) . '_' .$key:$key;
-            
+
             $data[$key] = $record->toArray($deep, $prefixKey);
         }
-        
+
         return $data;
     }
 
     /**
      * Build an array made up of the values from the 2 specified columns
      *
-     * @param string $key 
-     * @param string $value 
+     * @param string $key
+     * @param string $value
      * @return array $result
      */
     public function toKeyValueArray($key, $value)
@@ -804,7 +807,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     /**
      * Populate a Doctrine_Collection from an array of data
      *
-     * @param string $array 
+     * @param string $array
      * @return void
      */
     public function fromArray($array, $deep = true)
@@ -852,8 +855,8 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     /**
      * Export a Doctrine_Collection to one of the supported Doctrine_Parser formats
      *
-     * @param string $type 
-     * @param string $deep 
+     * @param string $type
+     * @param string $deep
      * @return void
      */
     public function exportTo($type, $deep = true)
@@ -868,8 +871,8 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     /**
      * Import data to a Doctrine_Collection from one of the supported Doctrine_Parser formats
      *
-     * @param string $type 
-     * @param string $data 
+     * @param string $type
+     * @param string $data
      * @return void
      */
     public function importFrom($type, $data)
@@ -906,8 +909,8 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      *
 	 * @throws Doctrine_Collection_Exception
 	 *
-     * @param Doctrine_Record $a 
-     * @param Doctrine_Record $b 
+     * @param Doctrine_Record $a
+     * @param Doctrine_Record $b
      * @return integer
      */
     protected function compareRecords($a, $b)
@@ -924,23 +927,25 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
         if ($a->getOid() == $b->getOid()) {
             return 0;
         }
-        
+
         return ($a->getOid() > $b->getOid()) ? 1 : -1;
     }
 
     /**
-     * Saves all records of this collection and processes the 
+     * Saves all records of this collection and processes the
      * difference of the last snapshot and the current data
      *
-     * @param Doctrine_Connection $conn     optional connection parameter
+     * @param Doctrine_Connection|null $conn     optional connection parameter
      * @return Doctrine_Collection
      */
-    public function save(Doctrine_Connection $conn = null, $processDiff = true)
+    public function save($conn = null, $processDiff = true)
     {
+        Types::isNullable('conn', $conn, 'Doctrine_Connection');
+
         if ($conn == null) {
             $conn = $this->_table->getConnection();
         }
-        
+
         try {
             $conn->beginInternalTransaction();
 
@@ -964,14 +969,16 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     }
 
     /**
-     * Replaces all records of this collection and processes the 
+     * Replaces all records of this collection and processes the
      * difference of the last snapshot and the current data
      *
-     * @param Doctrine_Connection $conn     optional connection parameter
+     * @param Doctrine_Connection|null $conn     optional connection parameter
      * @return Doctrine_Collection
      */
-    public function replace(Doctrine_Connection $conn = null, $processDiff = true)
+    public function replace($conn = null, $processDiff = true)
     {
+        Types::isNullable('conn', $conn, 'Doctrine_Connection');
+
         if ($conn == null) {
             $conn = $this->_table->getConnection();
         }
@@ -1003,12 +1010,14 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      *
      * @return Doctrine_Collection
      */
-    public function delete(Doctrine_Connection $conn = null, $clearColl = true)
+    public function delete($conn = null, $clearColl = true)
     {
+        Types::isNullable('conn', $conn, 'Doctrine_Connection');
+
         if ($conn == null) {
             $conn = $this->_table->getConnection();
         }
-        
+
         try {
             $conn->beginInternalTransaction();
             $conn->transaction->addCollection($this);
@@ -1022,14 +1031,14 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
             $conn->rollback();
             throw $e;
         }
-        
+
         if ($clearColl) {
             $this->clear();
         }
-        
+
         return $this;
     }
-    
+
     /**
      * Clears the collection.
      *
@@ -1084,7 +1093,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     {
         return Doctrine_Lib::getCollectionAsString($this);
     }
-    
+
     /**
      * Returns the relation object
      *
@@ -1095,22 +1104,22 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
         return $this->relation;
     }
 
-    /** 
-     * checks if one of the containing records is modified 
-     * returns true if modified, false otherwise 
-     *  
-     * @return boolean  
-     */ 
-    final public function isModified() { 
-        $dirty = (count($this->getInsertDiff()) > 0 || count($this->getDeleteDiff()) > 0); 
-        if ( ! $dirty) {  
-            foreach($this as $record) { 
+    /**
+     * checks if one of the containing records is modified
+     * returns true if modified, false otherwise
+     *
+     * @return boolean
+     */
+    final public function isModified() {
+        $dirty = (count($this->getInsertDiff()) > 0 || count($this->getDeleteDiff()) > 0);
+        if ( ! $dirty) {
+            foreach($this as $record) {
                 if ($dirty = $record->isModified()) {
                     break;
-                } 
-            } 
-        } 
-        return $dirty; 
+                }
+            }
+        }
+        return $dirty;
     }
 
     // [OV2] added

--- a/lib/Doctrine/Connection/Mssql.php
+++ b/lib/Doctrine/Connection/Mssql.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /*
  *  $Id: Mssql.php 7690 2010-08-31 17:11:24Z jwage $
  *
@@ -86,17 +89,17 @@ class Doctrine_Connection_Mssql extends Doctrine_Connection_Common
         if ($checkOption && ! $this->getAttribute(Doctrine_Core::ATTR_QUOTE_IDENTIFIER)) {
             return $identifier;
         }
-        
-        if (strpos($identifier, '.') !== false) { 
-            $parts = explode('.', $identifier); 
-            $quotedParts = array(); 
-            foreach ($parts as $p) { 
-                $quotedParts[] = $this->quoteIdentifier($p); 
+
+        if (strpos($identifier, '.') !== false) {
+            $parts = explode('.', $identifier);
+            $quotedParts = array();
+            foreach ($parts as $p) {
+                $quotedParts[] = $this->quoteIdentifier($p);
             }
-            
-            return implode('.', $quotedParts); 
+
+            return implode('.', $quotedParts);
         }
-        
+
         return '[' . str_replace(']', ']]', $identifier) . ']';
     }
 
@@ -108,21 +111,21 @@ class Doctrine_Connection_Mssql extends Doctrine_Connection_Common
      *
      * Copyright (c) 2005-2008, Zend Technologies USA, Inc.
      * All rights reserved.
-     * 
+     *
      * Redistribution and use in source and binary forms, with or without modification,
      * are permitted provided that the following conditions are met:
-     * 
+     *
      *     * Redistributions of source code must retain the above copyright notice,
      *       this list of conditions and the following disclaimer.
-     * 
+     *
      *     * Redistributions in binary form must reproduce the above copyright notice,
      *       this list of conditions and the following disclaimer in the documentation
      *       and/or other materials provided with the distribution.
-     * 
+     *
      *     * Neither the name of Zend Technologies USA, Inc. nor the names of its
      *       contributors may be used to endorse or promote products derived from this
      *       software without specific prior written permission.
-     * 
+     *
      * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
      * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
      * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -140,10 +143,12 @@ class Doctrine_Connection_Mssql extends Doctrine_Connection_Common
      * @link http://lists.bestpractical.com/pipermail/rt-devel/2005-June/007339.html
      * @return string
      */
-    public function modifyLimitQuery($query, $limit = false, $offset = false, $isManip = false, $isSubQuery = false, Doctrine_Query $queryOrigin = null)
+    public function modifyLimitQuery($query, $limit = false, $offset = false, $isManip = false, $isSubQuery = false, $queryOrigin = null)
     {
+        Types::isNullable('queryOrigin', $queryOrigin, 'Doctrine_Query');
+
         if ($limit === false || !($limit > 0)) {
-            return $query; 
+            return $query;
         }
 
         $orderby = stristr($query, 'ORDER BY');
@@ -151,7 +156,7 @@ class Doctrine_Connection_Mssql extends Doctrine_Connection_Common
         if ($offset !== false && $orderby === false) {
             throw new Doctrine_Connection_Exception("OFFSET cannot be used in MSSQL without ORDER BY due to emulation reasons.");
         }
-        
+
         $count = intval($limit);
         $offset = intval($offset);
 
@@ -206,14 +211,14 @@ class Doctrine_Connection_Mssql extends Doctrine_Connection_Common
         }
 
         if ($orderby !== false) {
-            $query .= ' ORDER BY '; 
+            $query .= ' ORDER BY ';
 
-            for ($i = 0, $l = count($orders); $i < $l; $i++) { 
-                if ($i > 0) { // not first order clause 
-                    $query .= ', '; 
-                } 
+            for ($i = 0, $l = count($orders); $i < $l; $i++) {
+                if ($i > 0) { // not first order clause
+                    $query .= ', ';
+                }
 
-                $query .= $this->modifyOrderByColumn($tables[$i], $columns[$i], $this->quoteIdentifier('inner_tbl') . '.' . $this->quoteIdentifier($aliases[$i])) . ' '; 
+                $query .= $this->modifyOrderByColumn($tables[$i], $columns[$i], $this->quoteIdentifier('inner_tbl') . '.' . $this->quoteIdentifier($aliases[$i])) . ' ';
                 $query .= (stripos($sorts[$i], 'asc') !== false) ? 'DESC' : 'ASC';
             }
         }
@@ -238,8 +243,8 @@ class Doctrine_Connection_Mssql extends Doctrine_Connection_Common
     }
 
     /**
-     * Parse an OrderBy-Statement into chunks 
-     * 
+     * Parse an OrderBy-Statement into chunks
+     *
      * @param string $orderby
      */
     private function parseOrderBy($orderby)
@@ -250,16 +255,16 @@ class Doctrine_Connection_Mssql extends Doctrine_Connection_Common
         $parsed  = str_ireplace('ORDER BY', '', $orderby);
 
         preg_match_all('/(\w+\(.+?\)\s+(ASC|DESC)),?/', $orderby, $matches);
-        
+
         $matchesWithExpressions = $matches[1];
 
         foreach ($matchesWithExpressions as $match) {
             $chunks[] = $match;
             $parsed = str_replace($match, '##' . (count($chunks) - 1) . '##', $parsed);
         }
-        
+
         $tokens = preg_split('/,/', $parsed);
-        
+
         for ($i = 0, $iMax = count($tokens); $i < $iMax; $i++) {
 
             $tokens[$i] = trim(preg_replace_callback(
@@ -273,15 +278,15 @@ class Doctrine_Connection_Mssql extends Doctrine_Connection_Common
 
         return $tokens;
     }
-    
+
     /**
      * Order and Group By are not possible on columns from type text.
-     * This method fix this issue by wrap the given term (column) into a CAST directive. 
-     * 
+     * This method fix this issue by wrap the given term (column) into a CAST directive.
+     *
      * @see DC-828
      * @param Doctrine_Table $table
      * @param string $field
-     * @param string $term The term which will changed if it's necessary, depending to the field type. 
+     * @param string $term The term which will changed if it's necessary, depending to the field type.
      * @return string
      */
     public function modifyOrderByColumn(Doctrine_Table $table, $field, $term)
@@ -291,7 +296,7 @@ class Doctrine_Connection_Mssql extends Doctrine_Connection_Common
         if ($def['type'] == 'string' && $def['length'] === NULL) {
             $term = 'CAST(' . $term . ' AS varchar(8000))';
         }
-        
+
         return $term;
     }
 
@@ -305,7 +310,7 @@ class Doctrine_Connection_Mssql extends Doctrine_Connection_Common
     {
         return $this->modifyLimitQuery($query, $limit, $offset, $isManip, true);
     }
-    
+
     /**
      * return version information about the server
      *

--- a/lib/Doctrine/Locator.php
+++ b/lib/Doctrine/Locator.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  *  $Id$
  *
@@ -45,7 +48,7 @@ class Doctrine_Locator implements Countable, IteratorAggregate
      */
     protected $_classPrefix = 'Doctrine_';
 
-    /** 
+    /**
      * @var array $_instances       a pool of this object's instances
      */
     protected static $_instances = array();
@@ -53,11 +56,13 @@ class Doctrine_Locator implements Countable, IteratorAggregate
     /**
      * Constructor. Provide an array of resources to set initial contents.
      *
-     * @param array
+     * @param array|null
      * @return void
      */
-    public function __construct(array $defaults = null)
+    public function __construct($defaults = null)
     {
+        Types::isNullable('defaults', $defaults, 'array');
+
         if (null !== $defaults) {
             foreach ($defaults as $name => $resource) {
                 if ($resource instanceof Doctrine_Locator_Injectable) {
@@ -69,7 +74,7 @@ class Doctrine_Locator implements Countable, IteratorAggregate
         self::$_instances[] = $this;
     }
 
-    /** 
+    /**
      * instance
      *
      * @return Sensei_Locator
@@ -87,7 +92,7 @@ class Doctrine_Locator implements Countable, IteratorAggregate
      *
      * @param string $prefix
      */
-    public function setClassPrefix($prefix) 
+    public function setClassPrefix($prefix)
     {
         $this->_classPrefix = $prefix;
     }
@@ -124,7 +129,7 @@ class Doctrine_Locator implements Countable, IteratorAggregate
     public function bind($name, $value)
     {
         $this->_resources[$name] = $value;
-        
+
         return $this;
     }
 
@@ -149,9 +154,9 @@ class Doctrine_Locator implements Countable, IteratorAggregate
                 $name = array_map('strtolower', $name);
                 $name = array_map('ucfirst', $name);
                 $name = implode('_', $name);
-                
+
                 $className = $this->_classPrefix . $name;
-                
+
                 if ( ! class_exists($className)) {
                     throw new Doctrine_Locator_Exception("Couldn't locate resource " . $className);
                 }
@@ -184,10 +189,10 @@ class Doctrine_Locator implements Countable, IteratorAggregate
 
     /**
      * getIterator
-     * returns an ArrayIterator that iterates through all 
+     * returns an ArrayIterator that iterates through all
      * bound resources
      *
-     * @return ArrayIterator    an iterator for iterating through 
+     * @return ArrayIterator    an iterator for iterating through
      *                          all bound resources
      */
     public function getIterator()

--- a/lib/Doctrine/Query.php
+++ b/lib/Doctrine/Query.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /*
  *  $Id: Query.php 7674 2010-06-08 22:59:01Z jwage $
  *
@@ -2636,10 +2639,12 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
     /**
      * Copies a Doctrine_Query object.
      *
-     * @return Doctrine_Query  Copy of the Doctrine_Query instance.
+     * @return Doctrine_Query|null  Copy of the Doctrine_Query instance.
      */
-    public function copy(Doctrine_Query $query = null)
+    public function copy($query = null)
     {
+        Types::isNullable('query', $query, 'Doctrine_Query');
+
         if ( ! $query) {
             $query = $this;
         }

--- a/lib/Doctrine/Query/Abstract.php
+++ b/lib/Doctrine/Query/Abstract.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /*
  *  $Id: Query.php 1393 2007-05-19 17:49:16Z zYne $
  *
@@ -227,7 +230,7 @@ abstract class Doctrine_Query_Abstract
      * @var string
      */
     protected $_rootAlias = '';
-    
+
     /**
      * @var integer $type                   the query type
      *
@@ -308,12 +311,15 @@ abstract class Doctrine_Query_Abstract
     /**
      * Constructor.
      *
-     * @param Doctrine_Connection  The connection object the query will use.
-     * @param Doctrine_Hydrator_Abstract  The hydrator that will be used for generating result sets.
+     * @param Doctrine_Connection|null $connection      The connection object the query will use.
+     * @param Doctrine_Hydrator_Abstract|null $hydrator The hydrator that will be used for generating result sets.
      */
-    public function __construct(Doctrine_Connection $connection = null,
-            Doctrine_Hydrator_Abstract $hydrator = null)
+    public function __construct($connection = null,
+            $hydrator = null)
     {
+        Types::isNullable('connection', $connection, 'Doctrine_Connection');
+        Types::isNullable('hydrator', $hydrator, 'Doctrine_Hydrator_Abstract');
+
         if ($connection === null) {
             $connection = Doctrine_Manager::getInstance()->getCurrentConnection();
         } else {
@@ -424,7 +430,7 @@ abstract class Doctrine_Query_Abstract
     {
         $dql = $this->getDql();
         $params = $this->getFlattenedParams();
-        
+
         // [OV13]
         $dql = $this->_adjustWhereInSql($dql, $params);
 
@@ -570,7 +576,7 @@ abstract class Doctrine_Query_Abstract
     public function getFlattenedParams($params = array())
     {
         return array_merge(
-            (array) $params, (array) $this->_params['exec'], 
+            (array) $params, (array) $this->_params['exec'],
             $this->_params['join'], $this->_params['set'],
             $this->_params['where'], $this->_params['having']
         );
@@ -595,7 +601,7 @@ abstract class Doctrine_Query_Abstract
     {
         $this->_params = $params;
     }
-    
+
     /**
      * getCountQueryParams
      * Retrieves the parameters for count query
@@ -627,7 +633,7 @@ abstract class Doctrine_Query_Abstract
      * @param int $index
      * @return array
      */
-    protected function _adjustProcessedParam(array $params = null, $index)
+    protected function _adjustProcessedParam($params, $index)
     {
         // Retrieve all params
         $params = null !== $params ? $params : $this->getInternalParams();
@@ -655,13 +661,13 @@ abstract class Doctrine_Query_Abstract
                 $c = count($param);
 
                 array_splice($params, $i, 1, $param);
-                
+
                 $i += $c;
             } else {
                 $i++;
             }
         }
-        
+
         $this->_execParams = $params;
     }
 
@@ -728,17 +734,17 @@ abstract class Doctrine_Query_Abstract
             $tableAlias .= '.';
         }
 
-        // Fix for 2015: loop through whole inheritanceMap to add all   
-        // keyFields for inheritance (and not only the first) 
-        $retVal = ""; 
-        $count = 0; 
-         
-        foreach ($map as $field => $value) { 
+        // Fix for 2015: loop through whole inheritanceMap to add all
+        // keyFields for inheritance (and not only the first)
+        $retVal = "";
+        $count = 0;
+
+        foreach ($map as $field => $value) {
             if ($count++ > 0) {
                 $retVal .= ' AND ';
             }
 
-            $identifier = $this->_conn->quoteIdentifier($tableAlias . $field); 
+            $identifier = $this->_conn->quoteIdentifier($tableAlias . $field);
             $retVal .= $identifier . ' = ' . $this->_conn->quote($value);
         }
 
@@ -877,7 +883,7 @@ abstract class Doctrine_Query_Abstract
         if ( ! $this->_queryComponents) {
             $this->getSqlQuery(array(), false);
         }
-        
+
         return $this->_rootAlias;
     }
 
@@ -1052,13 +1058,13 @@ abstract class Doctrine_Query_Abstract
                 if ($cached) {
                     // Rebuild query from cache
                     $query = $this->_constructQueryFromCache($cached);
-                    
+
                     // Assign building/execution specific params
                     $this->_params['exec'] = $params;
-            
+
                     // Initialize prepared parameters array
                     $this->_execParams = $this->getFlattenedParams();
-                    
+
                     // Fix possible array parameter values in SQL params
                     $this->fixArrayParameterValues($this->getInternalParams());
                 } else {
@@ -1081,7 +1087,7 @@ abstract class Doctrine_Query_Abstract
         } else {
             $query = $this->_view->getSelectSql();
         }
-        
+
         // Get prepared SQL params for execution
         $params = $this->getInternalParams();
 
@@ -1166,7 +1172,7 @@ abstract class Doctrine_Query_Abstract
                 $this->_hydrator->setQueryComponents($this->_queryComponents);
                 if ($this->_type == self::SELECT && $hydrationMode == Doctrine_Core::HYDRATE_ON_DEMAND) {
                     $hydrationDriver = $this->_hydrator->getHydratorDriver($hydrationMode, $this->_tableAliasMap);
-                    $result = new Doctrine_Collection_OnDemand($stmt, $hydrationDriver, $this->_tableAliasMap); 
+                    $result = new Doctrine_Collection_OnDemand($stmt, $hydrationDriver, $this->_tableAliasMap);
                 } else {
                     $result = $this->_hydrator->hydrateResultSet($stmt, $this->_tableAliasMap);
                 }
@@ -1183,7 +1189,7 @@ abstract class Doctrine_Query_Abstract
      * Blank template method free(). Override to be used to free query object memory
      */
     public function free()
-    { 
+    {
     }
 
     /**
@@ -1245,7 +1251,7 @@ abstract class Doctrine_Query_Abstract
                 // Trigger preDql*() callback event
                 $params = array('component' => $component, 'alias' => $alias);
                 $event = new Doctrine_Event($record, $callback['const'], $this, $params);
-                
+
                 $record->{$callback['callback']}($event);
                 $table->getRecordListener()->{$callback['callback']}($event);
             }
@@ -1318,9 +1324,9 @@ abstract class Doctrine_Query_Abstract
         foreach ($cachedComponents as $alias => $components) {
             $e = explode('.', $components['name']);
             if (count($e) === 1) {
-                $manager = Doctrine_Manager::getInstance(); 
-                if ( ! $this->_passedConn && $manager->hasConnectionForComponent($e[0])) { 
-                    $this->_conn = $manager->getConnectionForComponent($e[0]); 
+                $manager = Doctrine_Manager::getInstance();
+                if ( ! $this->_passedConn && $manager->hasConnectionForComponent($e[0])) {
+                    $this->_conn = $manager->getConnectionForComponent($e[0]);
                 }
                 $queryComponents[$alias]['table'] = $this->_conn->getTable($e[0]);
             } else {
@@ -1586,7 +1592,7 @@ abstract class Doctrine_Query_Abstract
             // [OV13] just store the params array
             $this->_params['where'][] = $params;
         }
-        
+
         return $expr . ($not === true ? ' NOT' : '') . ' IN ' . ($mixed ? '(' . implode(', ', $a) . ')' : '?');
     }
 
@@ -1707,7 +1713,7 @@ abstract class Doctrine_Query_Abstract
     /**
      * Adds conditions to the HAVING part of the query.
      *
-     * This methods add HAVING clauses. These clauses are used to narrow the 
+     * This methods add HAVING clauses. These clauses are used to narrow the
      * results by operating on aggregated values.
      * <code>
      * $q->having('num_phonenumbers > ?', 1);

--- a/lib/Doctrine/Query/Part.php
+++ b/lib/Doctrine/Query/Part.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /*
  *  $Id: Part.php 7490 2010-03-29 19:53:27Z jwage $
  *
@@ -36,14 +39,16 @@ abstract class Doctrine_Query_Part
      * @var Doctrine_Query $query           the query object associated with this parser
      */
     protected $query;
-    
+
     protected $_tokenizer;
 
     /**
      * @param Doctrine_Query $query         the query object associated with this parser
      */
-    public function __construct($query, Doctrine_Query_Tokenizer $tokenizer = null)
+    public function __construct($query, $tokenizer = null)
     {
+        Types::isNullable('tokenizer', $tokenizer, 'Doctrine_Query_Tokenizer');
+
         $this->query = $query;
 
         if ( ! $tokenizer) {

--- a/lib/Doctrine/RawSql.php
+++ b/lib/Doctrine/RawSql.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /*
  *  $Id: RawSql.php 7490 2010-03-29 19:53:27Z jwage $
  *
@@ -46,10 +49,13 @@ class Doctrine_RawSql extends Doctrine_Query_Abstract
     /**
      * Constructor.
      *
-     * @param Doctrine_Connection  The connection object the query will use.
-     * @param Doctrine_Hydrator_Abstract  The hydrator that will be used for generating result sets.
+     * @param Doctrine_Connection|null  The connection object the query will use.
+     * @param Doctrine_Hydrator_Abstract|null  The hydrator that will be used for generating result sets.
      */
-    function __construct(Doctrine_Connection $connection = null, Doctrine_Hydrator_Abstract $hydrator = null) {
+    function __construct($connection = null, $hydrator = null) {
+        Types::isNullable('connection', $connection, 'Doctrine_Connection');
+        Types::isNullable('hydrator', $hydrator, 'Doctrine_Hydrator_Abstract');
+
         parent::__construct($connection, $hydrator);
 
         // Fix #1472. It's alid to disable QueryCache since there's no DQL for RawSql.
@@ -87,7 +93,7 @@ class Doctrine_RawSql extends Doctrine_Query_Abstract
      	if ( ! isset($this->_sqlParts[$queryPartName])) {
      	    $this->_sqlParts[$queryPartName] = array();
      	}
-     	
+
      	if ( ! $append) {
      	    $this->_sqlParts[$queryPartName] = array($queryPart);
      	} else {
@@ -95,7 +101,7 @@ class Doctrine_RawSql extends Doctrine_Query_Abstract
      	}
      	return $this;
     }
-    
+
     /**
      * Adds a DQL query part. Overrides Doctrine_Query_Abstract::_addDqlQueryPart().
      * This implementation for RawSql parses the new parts right away, generating the SQL.
@@ -104,7 +110,7 @@ class Doctrine_RawSql extends Doctrine_Query_Abstract
     {
         return $this->parseDqlQueryPart($queryPartName, $queryPart, $append);
     }
-    
+
     /**
      * Add select parts to fields.
      *
@@ -116,7 +122,7 @@ class Doctrine_RawSql extends Doctrine_Query_Abstract
         $this->fields = $m[1];
         $this->_sqlParts['select'] = array();
     }
-    
+
     /**
      * parseDqlQuery
      * parses an sql query and adds the parts to internal array.
@@ -168,7 +174,7 @@ class Doctrine_RawSql extends Doctrine_Query_Abstract
                         $parts[$type][0] = $part;
                     } else {
                         // why does this add to index 0 and not append to the
-                        // array. If it had done that one could have used 
+                        // array. If it had done that one could have used
                         // parseQueryPart.
                         $parts[$type][0] .= ' '.$part;
                     }
@@ -188,7 +194,7 @@ class Doctrine_RawSql extends Doctrine_Query_Abstract
      * @return string       the built sql query
      */
     public function getSqlQuery($params = array())
-    {        
+    {
         // Assign building/execution specific params
         $this->_params['exec'] = $params;
 
@@ -199,7 +205,7 @@ class Doctrine_RawSql extends Doctrine_Query_Abstract
         $this->fixArrayParameterValues($this->_execParams);
 
         $select = array();
-        
+
         $formatter = $this->getConnection()->formatter;
 
         foreach ($this->fields as $field) {
@@ -217,7 +223,7 @@ class Doctrine_RawSql extends Doctrine_Query_Abstract
             }
 
             $componentAlias = $this->getComponentAlias($e[0]);
-            
+
             if ($e[1] == '*') {
                 foreach ($this->_queryComponents[$componentAlias]['table']->getColumnNames() as $name) {
                     $field = $formatter->quoteIdentifier($e[0]) . '.' . $formatter->quoteIdentifier($name);
@@ -254,7 +260,7 @@ class Doctrine_RawSql extends Doctrine_Query_Abstract
         // first add the fields of the root component
         reset($this->_queryComponents);
         $componentAlias = key($this->_queryComponents);
-        
+
         $this->_rootAlias = $componentAlias;
 
         $q .= implode(', ', $select[$componentAlias]);
@@ -422,7 +428,7 @@ class Doctrine_RawSql extends Doctrine_Query_Abstract
             if ( ! isset($table)) {
                 $conn = Doctrine_Manager::getInstance()
                         ->getConnectionForComponent($component);
-                        
+
                 $table = $conn->getTable($component);
                 $this->_queryComponents[$componentAlias] = array('table' => $table);
             } else {

--- a/lib/Doctrine/Record.php
+++ b/lib/Doctrine/Record.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /*
  *  $Id: Record.php 7673 2010-06-08 20:49:54Z jwage $
  *
@@ -151,7 +154,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * @var string
      */
     protected $_pendingDeletes = array();
-    
+
     /**
      * Array of pending un links in format alias => keys to be executed after save
      *
@@ -275,7 +278,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
         }
 
         $repository = $this->_table->getRepository();
-        
+
         // Fix for #1682 and #1841.
         // Doctrine_Table does not have the repository yet during dummy record creation.
         if ($repository) {
@@ -415,9 +418,9 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
         $event = new Doctrine_Event($this, Doctrine_Event::RECORD_VALIDATE);
         $this->preValidate($event);
         $this->getTable()->getRecordListener()->preValidate($event);
-        
+
         if ( ! $event->skipOperation) {
-        
+
             $validator = new Doctrine_Validator();
             $validator->validateRecord($this);
             $this->validate();
@@ -578,7 +581,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
 
     /**
      * Empty template method to provide concrete Record classes with the possibility
-     * to hook into the validation procedure. Useful for cleaning up data before 
+     * to hook into the validation procedure. Useful for cleaning up data before
      * validating it.
      */
     public function preValidate($event)
@@ -612,14 +615,14 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
     { }
 
     /**
-     * Empty template method to provide Record classes with the ability to alter hydration 
+     * Empty template method to provide Record classes with the ability to alter hydration
      * before it runs
      */
     public function preHydrate($event)
     { }
 
     /**
-     * Empty template method to provide Record classes with the ability to alter hydration 
+     * Empty template method to provide Record classes with the ability to alter hydration
      * after it runs
      */
     public function postHydrate($event)
@@ -658,7 +661,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
         if ( ! $this->_errorStack) {
             $this->_errorStack = new Doctrine_Validator_ErrorStack(get_class($this));
         }
-        
+
         return $this->_errorStack;
     }
 
@@ -937,7 +940,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
         $connection = $manager->getConnectionForComponent(get_class($this));
 
         $this->_table = $connection->getTable(get_class($this));
-        
+
         $this->preUnserialize($event);
         $this->getTable()->getRecordListener()->preUnserialize($event);
 
@@ -1000,7 +1003,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
         if ($state == null) {
             return $this->_state;
         }
-        
+
         $err = false;
         if (is_integer($state)) {
             if ($state >= 1 && $state <= 7) {
@@ -1151,7 +1154,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * in order to check. If the reference didn't already exist and it doesn't
      * exist in the database, the related reference will be cleared immediately.
      *
-     * @param string $name 
+     * @param string $name
      * @return boolean Whether or not the related relationship exists
      */
     public function relatedExists($name)
@@ -1231,18 +1234,18 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
         // only load the data from database if the Doctrine_Record is in proxy state
         if ($this->exists() && $this->isInProxyState()) {
             $id = $this->identifier();
-            
+
             if ( ! is_array($id)) {
                 $id = array($id);
             }
-            
+
             if (empty($id)) {
                 return false;
             }
 
             $table = $this->getTable();
             $data = empty($data) ? $table->find($id, Doctrine_Core::HYDRATE_ARRAY) : $data;
-            
+
             if (is_array($data)) {
                 foreach ($data as $field => $value) {
                     if ($table->hasField($field) && ( ! array_key_exists($field, $this->_data) || $this->_data[$field] === self::$_null)) {
@@ -1250,19 +1253,19 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
                    }
                 }
             }
-            
+
             if ($this->isModified()) {
                 $this->_state = Doctrine_Record::STATE_DIRTY;
             } else if (!$this->isInProxyState()) {
                 $this->_state = Doctrine_Record::STATE_CLEAN;
             }
-            
+
             return true;
         }
-        
+
         return false;
     }
-        
+
     /**
      * indicates whether record has any not loaded fields
      *
@@ -1286,8 +1289,8 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * sets a fieldname to have a custom accessor or check if a field has a custom
      * accessor defined (when called without $accessor parameter).
      *
-     * @param string $fieldName 
-     * @param string $accessor 
+     * @param string $fieldName
+     * @param string $accessor
      * @return boolean
      */
     public function hasAccessor($fieldName, $accessor = null)
@@ -1303,7 +1306,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
     /**
      * clears the accessor for a field name
      *
-     * @param string $fieldName 
+     * @param string $fieldName
      * @return void
      */
     public function clearAccessor($fieldName)
@@ -1315,7 +1318,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
     /**
      * gets the custom accessor for a field name
      *
-     * @param string $fieldName 
+     * @param string $fieldName
      * @return string $accessor
      */
     public function getAccessor($fieldName)
@@ -1341,8 +1344,8 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * sets a fieldname to have a custom mutator or check if a field has a custom
      * mutator defined (when called without the $mutator parameter)
      *
-     * @param string $fieldName 
-     * @param string $mutator 
+     * @param string $fieldName
+     * @param string $mutator
      * @return boolean
      */
     public function hasMutator($fieldName, $mutator = null)
@@ -1358,7 +1361,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
     /**
      * gets the custom mutator for a field name
      *
-     * @param string $fieldname 
+     * @param string $fieldname
      * @return string
      */
     public function getMutator($fieldName)
@@ -1372,7 +1375,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
     /**
      * clears the custom mutator for a field name
      *
-     * @param string $fieldName 
+     * @param string $fieldName
      * @return void
      */
     public function clearMutator($fieldName)
@@ -1418,7 +1421,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
         if ($this->_table->getAttribute(Doctrine_Core::ATTR_AUTO_ACCESSOR_OVERRIDE) || $this->hasAccessor($fieldName)) {
             $componentName = $this->_table->getComponentName();
 
-            $accessor = $this->hasAccessor($fieldName) 
+            $accessor = $this->hasAccessor($fieldName)
                 ? $this->getAccessor($fieldName)
                 : 'get' . Doctrine_Inflector::classify($fieldName);
 
@@ -1449,10 +1452,10 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
             } else {
                 $value = $this->_data[$fieldName];
             }
-            
+
             return $value;
         }
-        
+
         try {
             if ( ! isset($this->_references[$fieldName])) {
                 if ($load) {
@@ -1557,10 +1560,10 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
             } else {
                 $old = $this->_data[$fieldName];
             }
-            
+
             if ($this->_isValueModified($type, $old, $value)) {
                 if ($value === null) {
-                    $value = $this->_table->getDefaultValueOf($fieldName); 
+                    $value = $this->_table->getDefaultValueOf($fieldName);
                 }
                 $this->_data[$fieldName] = $value;
                 $this->_modified[] = $fieldName;
@@ -1647,7 +1650,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
     /**
      * Places a related component in the object graph.
      *
-     * This method inserts a related component instance in this record 
+     * This method inserts a related component instance in this record
      * relations, populating the foreign keys accordingly.
      *
      * @param string $name                                  related component alias in the relation
@@ -1657,11 +1660,11 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
     public function coreSetRelated($name, $value)
     {
         $rel = $this->_table->getRelation($name);
-        
+
         if ($value === null) {
             $value = self::$_null;
         }
-        
+
         // one-to-many or one-to-one relation
         if ($rel instanceof Doctrine_Relation_ForeignKey || $rel instanceof Doctrine_Relation_LocalKey) {
             if ( ! $rel->isOneToOne()) {
@@ -1819,12 +1822,14 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      *
      * this method also saves the related components
      *
-     * @param Doctrine_Connection $conn     optional connection parameter
+     * @param Doctrine_Connection|null $conn optional connection parameter
      * @throws Exception                    if record is not valid and validation is active
      * @return void
      */
-    public function save(Doctrine_Connection $conn = null)
+    public function save($conn = null)
     {
+        Types::isNullable('conn', $conn, 'Doctrine_Connection');
+
         if ($conn === null) {
             $conn = $this->_table->getConnection();
         }
@@ -1837,10 +1842,12 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * throw an exception when validation fails but returns TRUE on
      * success or FALSE on failure.
      *
-     * @param Doctrine_Connection $conn                 optional connection parameter
+     * @param Doctrine_Connection|null $conn            optional connection parameter
      * @return TRUE if the record was saved sucessfully without errors, FALSE otherwise.
      */
-    public function trySave(Doctrine_Connection $conn = null) {
+    public function trySave($conn = null) {
+        Types::isNullable('conn', $conn, 'Doctrine_Connection');
+
         try {
             $this->save($conn);
             return true;
@@ -1860,14 +1867,16 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * query isemulated through this method for other DBMS using standard types
      * of queries inside a transaction to assure the atomicity of the operation.
      *
-     * @param Doctrine_Connection $conn             optional connection parameter
+     * @param Doctrine_Connection|null $conn        optional connection parameter
      * @throws Doctrine_Connection_Exception        if some of the key values was null
      * @throws Doctrine_Connection_Exception        if there were no key fields
      * @throws Doctrine_Connection_Exception        if something fails at database level
      * @return integer                              number of rows affected
      */
-    public function replace(Doctrine_Connection $conn = null)
+    public function replace($conn = null)
     {
+        Types::isNullable('conn', $conn, 'Doctrine_Connection');
+
         if ($conn === null) {
             $conn = $this->_table->getConnection();
         }
@@ -1876,7 +1885,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
 
     /**
      * retrieves an array of modified fields and associated new values.
-     * 
+     *
      * @param boolean $old      pick the old values (instead of the new ones)
      * @param boolean $last     pick only lastModified values (@see getLastModified())
      * @return array $a
@@ -1888,8 +1897,8 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
         $modified = $last ? $this->_lastModified:$this->_modified;
         foreach ($modified as $fieldName) {
             if ($old) {
-                $a[$fieldName] = isset($this->_oldValues[$fieldName]) 
-                    ? $this->_oldValues[$fieldName] 
+                $a[$fieldName] = isset($this->_oldValues[$fieldName])
+                    ? $this->_oldValues[$fieldName]
                     : $this->getTable()->getDefaultValueOf($fieldName);
             } else {
                 $a[$fieldName] = $this->_data[$fieldName];
@@ -1913,7 +1922,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * Retrieves data prepared for a sql transaction.
      *
      * Returns an array of modified fields and values with data preparation;
-     * adds column aggregation inheritance and converts Records into primary 
+     * adds column aggregation inheritance and converts Records into primary
      * key values.
      *
      * @param array $array
@@ -2008,10 +2017,10 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
         if ($this->_state == self::STATE_LOCKED || $this->_state == self::STATE_TLOCKED) {
             return false;
         }
-        
+
         $stateBeforeLock = $this->_state;
         $this->_state = $this->exists() ? self::STATE_LOCKED : self::STATE_TLOCKED;
-        
+
         $a = array();
 
         foreach ($this as $column => $value) {
@@ -2306,8 +2315,10 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      *
      * @return boolean      true if successful
      */
-    public function delete(Doctrine_Connection $conn = null)
+    public function delete($conn = null)
     {
+        Types::isNullable('conn', $conn, 'Doctrine_Connection');
+
         if ($conn == null) {
             $conn = $this->_table->getConnection();
         }
@@ -2873,8 +2884,8 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
     }
 
     /**
-     * Reset the modified array and store the old array in lastModified so it 
-     * can be accessed by users after saving a record, since the modified array 
+     * Reset the modified array and store the old array in lastModified so it
+     * can be accessed by users after saving a record, since the modified array
      * is reset after the object is saved.
      *
      * @return void
@@ -2927,7 +2938,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
     {
         $this->getNode()->delete();
     }
-    
+
     /**
      * Helps freeing the memory occupied by the entity.
      * Cuts all references the entity has to other entities and removes the entity

--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /*
  *  $Id: Table.php 7681 2010-08-24 15:55:34Z jwage $
  *
@@ -1380,7 +1383,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
 
         $options['type'] = $type;
         $options['length'] = $length;
-        
+
         if (strtolower($fieldName) != $name) {
             $options['alias'] = $fieldName;
         }
@@ -2037,11 +2040,13 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
      *
      * @param string $fieldName
      * @param string $value
-     * @param Doctrine_Record $record   record to consider; if it does not exists, it is created
+     * @param Doctrine_Record|null $record   record to consider; if it does not exists, it is created
      * @return Doctrine_Validator_ErrorStack $errorStack
      */
-    public function validateField($fieldName, $value, Doctrine_Record $record = null)
+    public function validateField($fieldName, $value, $record = null)
     {
+        Types::isNullable('record', $record, 'Doctrine_Record');
+
         if ($record instanceof Doctrine_Record) {
             $errorStack = $record->getErrorStack();
         } else {
@@ -2191,8 +2196,10 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
      *
      * @return array numeric array
      */
-    public function getColumnNames(array $fieldNames = null)
+    public function getColumnNames($fieldNames = null)
     {
+        Types::isNullable('fieldNames', $fieldNames, 'array');
+
         if ($fieldNames === null) {
             return array_keys($this->_columns);
         } else {
@@ -2747,10 +2754,10 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
         $fieldsFound = $matches[1];
         $operatorFound = array_map('strtoupper', $matches[2]);
 
-        // Check if $fieldName has unidentified parts left 
+        // Check if $fieldName has unidentified parts left
         if (strlen(implode('', $fieldsFound) . implode('', $operatorFound)) !== strlen($fieldName)) {
             $expression = preg_replace('/(' . implode('|', $fields) . ')(Or|And)?/', '($1)$2', $fieldName);
-            throw new Doctrine_Table_Exception('Invalid expression found: ' . $expression);    
+            throw new Doctrine_Table_Exception('Invalid expression found: ' . $expression);
         }
 
         // Build result
@@ -2775,7 +2782,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
             }
 
             $where .= ' ' . strtoupper($operatorFound[$index]) . ' ';
-            
+
             $lastOperator = $operatorFound[$index];
         }
 

--- a/lib/Doctrine/Tree/Interface.php
+++ b/lib/Doctrine/Tree/Interface.php
@@ -35,9 +35,9 @@ interface Doctrine_Tree_Interface {
     /**
      * creates root node from given record or from a new record
      *
-     * @param Doctrine_Record $record                    instance of Doctrine_Record
+     * @param Doctrine_Record|null $record                    instance of Doctrine_Record
      */
-    public function createRoot(Doctrine_Record $record = null);
+    public function createRoot($record = null);
 
     /**
      * returns root node

--- a/lib/Doctrine/Tree/NestedSet.php
+++ b/lib/Doctrine/Tree/NestedSet.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /*
  *  $Id: NestedSet.php 7490 2010-03-29 19:53:27Z jwage $
  *
@@ -82,10 +85,12 @@ class Doctrine_Tree_NestedSet extends Doctrine_Tree implements Doctrine_Tree_Int
      * the records id will be assigned to the root id. You must use numeric columns for the id
      * and root id columns.
      *
-     * @param object $record        instance of Doctrine_Record
+     * @param object|null $record   instance of Doctrine_Record
      */
-    public function createRoot(Doctrine_Record $record = null)
+    public function createRoot($record = null)
     {
+        Types::isNullable('record', $record, 'Doctrine_Record');
+
         if ($this->getAttribute('hasManyRoots')) {
             if ( ! $record || ( ! $record->exists() && ! $record->getNode()->getRootValue())
                     || $record->getTable()->isIdentifierComposite()) {
@@ -94,14 +99,14 @@ class Doctrine_Tree_NestedSet extends Doctrine_Tree implements Doctrine_Tree_Int
                         . " be created as a root node. Automatic assignment of a root id on"
                         . " transient/new records is no longer supported.");
             }
-            
+
             if ($record->exists() && ! $record->getNode()->getRootValue()) {
                 // Default: root_id = id
                 $identifier = $record->getTable()->getIdentifier();
                 $record->getNode()->setRootValue($record->get($identifier));
             }
         }
-        
+
         if ( ! $record) {
             $record = $this->table->create();
         }
@@ -173,8 +178,8 @@ class Doctrine_Tree_NestedSet extends Doctrine_Tree implements Doctrine_Tree_Int
             $q->addOrderBy($this->_baseAlias . ".lft ASC");
         }
 
-        if ( ! is_null($depth)) { 
-            $q->addWhere($this->_baseAlias . ".level BETWEEN ? AND ?", array(0, $depth)); 
+        if ( ! is_null($depth)) {
+            $q->addWhere($this->_baseAlias . ".level BETWEEN ? AND ?", array(0, $depth));
         }
 
         $q = $this->returnQueryWithRootId($q, $rootId);
@@ -212,8 +217,8 @@ class Doctrine_Tree_NestedSet extends Doctrine_Tree implements Doctrine_Tree_Int
         $q->addWhere($this->_baseAlias . ".lft >= ? AND " . $this->_baseAlias . ".rgt <= ?", $params)
                 ->addOrderBy($this->_baseAlias . ".lft asc");
 
-        if ( ! is_null($depth)) { 
-            $q->addWhere($this->_baseAlias . ".level BETWEEN ? AND ?", array($record->get('level'), $record->get('level')+$depth)); 
+        if ( ! is_null($depth)) {
+            $q->addWhere($this->_baseAlias . ".level BETWEEN ? AND ?", array($record->get('level'), $record->get('level')+$depth));
         }
 
         $q = $this->returnQueryWithRootId($q, $record->getNode()->getRootValue());

--- a/tests/DoctrineTest/GroupTest.php
+++ b/tests/DoctrineTest/GroupTest.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 class GroupTest extends UnitTestCase
 {
     protected $_testCases = array();
@@ -51,8 +54,10 @@ class GroupTest extends UnitTestCase
         }
         return true;
     }
-    public function run(DoctrineTest_Reporter $reporter = null, $filter = null)
+    public function run($reporter = null, $filter = null)
     {
+    	Types::isNullable('reporter', $reporter, 'DoctrineTest_Reporter');
+
         set_time_limit(900);
         ini_set('memory_limit', '512M');
 

--- a/tests/DoctrineTest/UnitTestCase.php
+++ b/tests/DoctrineTest/UnitTestCase.php
@@ -1,10 +1,13 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 class UnitTestCase
 {
     protected $_passed = 0;
-    
+
     protected $_failed = 0;
-    
+
     protected $_messages = array();
 
     protected static $_passesAndFails = array('passes' => array(), 'fails' => array());
@@ -107,7 +110,7 @@ class UnitTestCase
         }
     }
 
-    public function pass() 
+    public function pass()
     {
         $class = get_class($this);
         if ( ! isset(self::$_passesAndFails['fails'][$class])) {
@@ -118,7 +121,7 @@ class UnitTestCase
 
     public function fail($message = "")
     {
-        $this->_fail($message);    
+        $this->_fail($message);
     }
 
     public function _fail($message = "")
@@ -149,20 +152,22 @@ class UnitTestCase
         self::$_passesAndFails['fails'][$class] = $class;
     }
 
-    public function run(DoctrineTest_Reporter $reporter = null, $filter = null) 
+    public function run($reporter = null, $filter = null)
     {
+        Types::isNullable('reporter', $reporter, 'DoctrineTest_Reporter');
+
         foreach (get_class_methods($this) as $method) {
             if (substr($method, 0, 4) === 'test') {
                 $this->setUp();
 
                 $this->$method();
-                
+
                 $this->tearDown();
             }
         }
     }
 
-    public function getMessages() 
+    public function getMessages()
     {
         return $this->_messages;
     }

--- a/tests/Ticket/1830TestCase.php
+++ b/tests/Ticket/1830TestCase.php
@@ -1,5 +1,6 @@
 <?php
 
+use Zf1s\Compat\Types;
 
 class Doctrine_Ticket_1830_TestCase extends Doctrine_UnitTestCase
 {
@@ -13,17 +14,19 @@ class Doctrine_Ticket_1830_TestCase extends Doctrine_UnitTestCase
         $this->prepareData();
     }
 
-    public function run(DoctrineTest_Reporter $reporter = null, $filter = null)
+    public function run($reporter = null, $filter = null)
     {
-      parent::run($reporter, $filter);
-      $this->manager->closeConnection($this->connection);
+        Types::isNullable('reporter', $reporter, 'DoctrineTest_Reporter');
+
+        parent::run($reporter, $filter);
+        $this->manager->closeConnection($this->connection);
     }
 
-    public function prepareData() 
+    public function prepareData()
     {
     }
-    
-    public function prepareTables() 
+
+    public function prepareTables()
     {
         try {
             $this->conn->exec('DROP TABLE ticket_1830__article_translation');

--- a/tests/Ticket/1876bTestCase.php
+++ b/tests/Ticket/1876bTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+use Zf1s\Compat\Types;
+
 class Doctrine_Ticket_1876b_TestCase extends Doctrine_UnitTestCase
 {
     public function init()
@@ -12,17 +14,19 @@ class Doctrine_Ticket_1876b_TestCase extends Doctrine_UnitTestCase
         $this->prepareData();
     }
 
-    public function run(DoctrineTest_Reporter $reporter = null, $filter = null)
+    public function run($reporter = null, $filter = null)
     {
-      parent::run($reporter, $filter);
-      $this->manager->closeConnection($this->connection);
+        Types::isNullable('reporter', $reporter, 'DoctrineTest_Reporter');
+
+        parent::run($reporter, $filter);
+        $this->manager->closeConnection($this->connection);
     }
 
-    public function prepareData() 
+    public function prepareData()
     {
     }
-    
-    public function prepareTables() 
+
+    public function prepareTables()
     {
         try {
             $this->conn->exec('DROP TABLE t1876b_recipe_ingredient');
@@ -30,11 +34,11 @@ class Doctrine_Ticket_1876b_TestCase extends Doctrine_UnitTestCase
             $this->conn->exec('DROP TABLE t1876b_company');
         } catch(Doctrine_Connection_Exception $e) {
         }
-        
+
         $this->tables = array(
             'T1876b_Recipe', 'T1876b_Company', 'T1876b_RecipeIngredient'
         );
-        
+
         parent::prepareTables();
     }
 
@@ -47,16 +51,16 @@ class Doctrine_Ticket_1876b_TestCase extends Doctrine_UnitTestCase
             $company->name = 'Test Company ' . ($i + 1);
             $company->save($this->connection);
         }
-        
+
         for ($i = 0; $i < 10; $i++) {
             $recipe = new T1876b_Recipe();
-            
+
             $recipe->name = 'test ' . $i;
             $recipe->company_id = ($i % 3 == 0) ? 1 : 2;
             $recipe->RecipeIngredients[]->name = 'test';
-            
+
             $recipe->save($this->connection);
-            
+
             if ($i % 2 == 0) {
                 $recipe->delete($this->connection);
             }
@@ -68,14 +72,14 @@ class Doctrine_Ticket_1876b_TestCase extends Doctrine_UnitTestCase
                 ->leftJoin('r.Company c')
                 ->leftJoin('r.RecipeIngredients')
                 ->addWhere('c.id = ?', 2);
-            
+
             $this->assertEqual(
-                $q->getCountSqlQuery(), 
+                $q->getCountSqlQuery(),
                 'SELECT COUNT(*) AS num_results FROM ('
                     . 'SELECT t.id FROM t1876b__recipe t '
                     . 'LEFT JOIN t1876b__company t2 ON t.company_id = t2.id AND t2.deleted_at IS NULL '
                     . 'LEFT JOIN t1876b__recipe_ingredient t3 ON t.id = t3.recipe_id AND t3.deleted_at IS NULL '
-                    . 'WHERE t2.id = ? AND (t.deleted_at IS NULL) GROUP BY t.id' 
+                    . 'WHERE t2.id = ? AND (t.deleted_at IS NULL) GROUP BY t.id'
                 . ') dctrn_count_query'
             );
             $this->assertEqual($q->count(), 3);
@@ -94,11 +98,11 @@ class T1876b_Recipe extends Doctrine_Record {
         $this->hasColumn('company_id', 'integer', null);
         $this->hasColumn('name', 'string', 255);
     }
-    
+
     public function setUp() {
         $this->hasOne('T1876b_Company as Company', array('local' => 'company_id', 'foreign' => 'id'));
         $this->hasMany('T1876b_RecipeIngredient as RecipeIngredients', array('local' => 'id', 'foreign' => 'recipe_id'));
-        
+
         $this->actAs('SoftDelete');
     }
 }
@@ -108,10 +112,10 @@ class T1876b_Company extends Doctrine_Record {
         $this->hasColumn('id', 'integer', null, array('autoincrement' => true, 'primary' => true));
         $this->hasColumn('name', 'string', 255);
     }
-    
+
     public function setUp() {
         $this->hasMany('T1876b_Recipe as Recipes', array('local' => 'id', 'foreign' => 'company_id'));
-        
+
         $this->actAs('SoftDelete');
     }
 }
@@ -122,10 +126,10 @@ class T1876b_RecipeIngredient extends Doctrine_Record {
         $this->hasColumn('recipe_id', 'integer', null);
         $this->hasColumn('name', 'string', 255);
     }
-    
+
     public function setUp() {
         $this->hasOne('T1876b_Recipe as Recipe', array('local' => 'recipe_id', 'foreign' => 'id'));
-        
+
         $this->actAs('SoftDelete');
     }
 }

--- a/tests/Ticket/1935TestCase.php
+++ b/tests/Ticket/1935TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+use Zf1s\Compat\Types;
+
 class Doctrine_Ticket_1935_TestCase extends Doctrine_UnitTestCase
 {
     public function init()
@@ -12,8 +14,10 @@ class Doctrine_Ticket_1935_TestCase extends Doctrine_UnitTestCase
         $this->prepareData();
     }
 
-    public function run(DoctrineTest_Reporter $reporter = null, $filter = null)
+    public function run($reporter = null, $filter = null)
     {
+        Types::isNullable('reporter', $reporter, 'DoctrineTest_Reporter');
+
         parent::run($reporter, $filter);
         $this->manager->closeConnection($this->connection);
     }


### PR DESCRIPTION
PHP 8.4: Implicitly nullable parameter declarations deprecated

https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

Fixes error:
Implicitly marking parameter ? as nullable is deprecated, the explicit nullable type must be used instead

Fix using Zf1s\Compat\Types
