### PR TITLE
PHP 8.4: E_STRICT constant deprecated

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,7 +6,10 @@ $startTime = time();
 // More info about that: http://bugs.php.net/bugs-generating-backtrace-win32.php
 //sleep(10);
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
+if (PHP_VERSION_ID < 70400) {
+    error_reporting(E_ALL | E_STRICT);
+}
 ini_set('max_execution_time', 900);
 ini_set('date.timezone', 'GMT+0');
 


### PR DESCRIPTION
PHP 8.4: E_STRICT constant deprecated
https://php.watch/versions/8.4/E_STRICT-deprecated